### PR TITLE
Save File  None is better 

### DIFF
--- a/dotbim/File.cs
+++ b/dotbim/File.cs
@@ -30,7 +30,7 @@ namespace dotbim
             {
                 JsonSerializer serializer = new JsonSerializer
                 {
-                    Formatting = Formatting.Indented
+                    Formatting = Formatting.None
                 };
                 serializer.Serialize(file, this);
             }


### PR DESCRIPTION
Keep storage with none is better for save size storage : 
Just quick example with file size 20mb
![image](https://github.com/paireks/dotbim/assets/31106432/cfc3a8ac-6dd3-48fd-8aa1-d4e65ec43bc6)
